### PR TITLE
GGEN-13 Soft Descriptor through Java SDK Transactions, GGEN-39 Soft Descriptor through Java SDK Auto Bill Transactions, GGEN-27 MCC through Java SDK

### DIFF
--- a/src/main/java/SecureNetRestApiSDK/Api/Models/ExtendedInformation.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Models/ExtendedInformation.java
@@ -168,6 +168,18 @@ public class ExtendedInformation
         softDescriptor = value;
     }
 
+	/**
+     * Displays a 4 characters dynamic merchant category code.
+     */
+    private String dynamicMCC = new String();
+    public String getDynamicMCC() {
+        return dynamicMCC;
+    }
+
+    public void setDynamicMCC(String value) {
+        dynamicMCC = value;
+    }
+
 }
 
 

--- a/src/main/java/SecureNetRestApiSDK/Api/Models/ExtendedInformation.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Models/ExtendedInformation.java
@@ -155,6 +155,18 @@ public class ExtendedInformation
     public void setInvoiceDescription(String value) {
         invoiceDescription = value;
     }
+	
+	/**
+     * Displays a description in addition to the merchants DBA.
+     */
+    private String softDescriptor = new String();
+    public String getSoftDescriptor() {
+        return softDescriptor;
+    }
+
+    public void setSoftDescriptor(String value) {
+        softDescriptor = value;
+    }
 
 }
 

--- a/src/main/java/SecureNetRestApiSDK/Api/Models/InstallmentPaymentPlan.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Models/InstallmentPaymentPlan.java
@@ -219,6 +219,16 @@ public class InstallmentPaymentPlan {
         userDefinedFields = value;
     }
 
+    private String softDescriptor = new String();
+
+    public String getSoftDescriptor() {
+        return softDescriptor;
+    }
+
+    public void setSoftDescriptor(String value) {
+        softDescriptor = value;
+    }
+
 }
 
 

--- a/src/main/java/SecureNetRestApiSDK/Api/Models/InstallmentPaymentPlan.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Models/InstallmentPaymentPlan.java
@@ -229,6 +229,15 @@ public class InstallmentPaymentPlan {
         softDescriptor = value;
     }
 
+    private String dynamicMCC = new String();
+    public String getDynamicMCC() {
+        return dynamicMCC;
+    }
+
+    public void setDynamicMCC(String value) {
+        dynamicMCC = value;
+    }
+
 }
 
 

--- a/src/main/java/SecureNetRestApiSDK/Api/Models/RecurringPaymentPlan.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Models/RecurringPaymentPlan.java
@@ -154,6 +154,16 @@ public class RecurringPaymentPlan
         userDefinedFields = value;
     }
 
+
+	private String softDescriptor = new String();
+    public String getSoftDescriptor() {
+        return softDescriptor;
+    }
+
+    public void setSoftDescriptor(String value) {
+        softDescriptor = value;
+    }
+	
 }
 
 

--- a/src/main/java/SecureNetRestApiSDK/Api/Models/RecurringPaymentPlan.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Models/RecurringPaymentPlan.java
@@ -163,7 +163,14 @@ public class RecurringPaymentPlan
     public void setSoftDescriptor(String value) {
         softDescriptor = value;
     }
-	
+
+    private String dynamicMCC = new String();
+    public String getDynamicMCC() {
+        return dynamicMCC;
+    }
+
+    public void setDynamicMCC(String value) {
+        dynamicMCC = value;
+    }
+
 }
-
-

--- a/src/main/java/SecureNetRestApiSDK/Api/Models/RecurringPaymentPlan.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Models/RecurringPaymentPlan.java
@@ -155,7 +155,7 @@ public class RecurringPaymentPlan
     }
 
 
-	private String softDescriptor = new String();
+    private String softDescriptor = new String();
     public String getSoftDescriptor() {
         return softDescriptor;
     }

--- a/src/main/java/SecureNetRestApiSDK/Api/Models/StoredInstallmentPaymentPlan.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Models/StoredInstallmentPaymentPlan.java
@@ -7,6 +7,14 @@ package SecureNetRestApiSDK.Api.Models;
 
 public class StoredInstallmentPaymentPlan   
 {
+    private String softDescriptor = new String();
+    public String getSoftDescriptor() {
+        return softDescriptor;
+    }
+
+    public void setSoftDescriptor(String value) {
+        softDescriptor = value;
+    }
 }
 
 

--- a/src/main/java/SecureNetRestApiSDK/Api/Models/StoredInstallmentPaymentPlan.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Models/StoredInstallmentPaymentPlan.java
@@ -15,6 +15,15 @@ public class StoredInstallmentPaymentPlan
     public void setSoftDescriptor(String value) {
         softDescriptor = value;
     }
+
+    private String dynamicMCC = new String();
+    public String getDynamicMCC() {
+        return dynamicMCC;
+    }
+
+    public void setDynamicMCC(String value) {
+        dynamicMCC = value;
+    }
 }
 
 

--- a/src/main/java/SecureNetRestApiSDK/Api/Models/StoredRecurringPaymentPlan.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Models/StoredRecurringPaymentPlan.java
@@ -171,6 +171,15 @@ public class StoredRecurringPaymentPlan
         softDescriptor = value;
     }
 
+    private String dynamicMCC = new String();
+    public String getDynamicMCC() {
+        return dynamicMCC;
+    }
+
+    public void setDynamicMCC(String value) {
+        dynamicMCC = value;
+    }
+
 }
 
 

--- a/src/main/java/SecureNetRestApiSDK/Api/Models/StoredRecurringPaymentPlan.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Models/StoredRecurringPaymentPlan.java
@@ -162,6 +162,15 @@ public class StoredRecurringPaymentPlan
         schedules = value;
     }
 
+    private String softDescriptor = new String();
+    public String getSoftDescriptor() {
+        return softDescriptor;
+    }
+
+    public void setSoftDescriptor(String value) {
+        softDescriptor = value;
+    }
+
 }
 
 

--- a/src/main/java/SecureNetRestApiSDK/Api/Models/StoredVariablePaymentPlan.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Models/StoredVariablePaymentPlan.java
@@ -52,6 +52,15 @@ public class StoredVariablePaymentPlan
         softDescriptor = value;
     }
 
+    private String dynamicMCC = new String();
+    public String getDynamicMCC() {
+        return dynamicMCC;
+    }
+
+    public void setDynamicMCC(String value) {
+        dynamicMCC = value;
+    }
+
 }
 
 

--- a/src/main/java/SecureNetRestApiSDK/Api/Models/StoredVariablePaymentPlan.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Models/StoredVariablePaymentPlan.java
@@ -4,17 +4,15 @@
 
 package SecureNetRestApiSDK.Api.Models;
 
-import java.util.Date;
-
 
 public class StoredVariablePaymentPlan   
 {
-    private Date planStartDate = new Date();
-    public Date getPlanStartDate() {
+    private Object planStartDate = new Object();
+    public Object getPlanStartDate() {
         return planStartDate;
     }
 
-    public void setPlanStartDate(Date value) {
+    public void setPlanStartDate(Object value) {
         planStartDate = value;
     }
 
@@ -43,6 +41,15 @@ public class StoredVariablePaymentPlan
 
     public void setNotes(String value) {
         notes = value;
+    }
+	
+    private String softDescriptor = new String();
+    public String getSoftDescriptor() {
+        return softDescriptor;
+    }
+
+    public void setSoftDescriptor(String value) {
+        softDescriptor = value;
     }
 
 }

--- a/src/main/java/SecureNetRestApiSDK/Api/Models/Transaction.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Models/Transaction.java
@@ -457,6 +457,15 @@ public class Transaction
         softDescriptor = value;
     }
 
+    private String dynamicMCC = new String();
+    public String getDynamicMCC() {
+        return dynamicMCC;
+    }
+
+    public void setDynamicMCC(String value) {
+        dynamicMCC = value;
+    }
+
 }
 
 

--- a/src/main/java/SecureNetRestApiSDK/Api/Models/Transaction.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Models/Transaction.java
@@ -448,6 +448,15 @@ public class Transaction
         imageResult = value;
     }
 
+    private String softDescriptor = new String();
+    public String getSoftDescriptor() {
+        return softDescriptor;
+    }
+
+    public void setSoftDescriptor(String value) {
+        softDescriptor = value;
+    }
+
 }
 
 

--- a/src/main/java/SecureNetRestApiSDK/Api/Models/VariablePaymentPlan.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Models/VariablePaymentPlan.java
@@ -7,8 +7,8 @@ import java.util.List;
 
 public class VariablePaymentPlan  extends StoredVariablePaymentPlan 
 {
-    private Date planEndDate = new Date();
-    public Date getPlanEndDate() {
+    private Object planEndDate = new Object();
+    public Object getPlanEndDate() {
         return planEndDate;
     }
 

--- a/src/main/java/SecureNetRestApiSDK/Api/Requests/CreditRequest.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Requests/CreditRequest.java
@@ -6,6 +6,7 @@ package SecureNetRestApiSDK.Api.Requests;
 
 import SNET.Core.HttpMethodEnum;
 import SecureNetRestApiSDK.Api.Models.Card;
+import SecureNetRestApiSDK.Api.Models.ExtendedInformation;
 
 public class CreditRequest  extends SecureNetRequest 
 {
@@ -27,6 +28,20 @@ public class CreditRequest  extends SecureNetRequest
         card = value;
     }
 
+
+	/**
+     * Additional data to assist in reporting, ecommerce or moto transactions,
+     * and level 2 or level 3 processing. Includes user-defined fields and
+     * invoice-related information.
+     */
+	private ExtendedInformation extendedInformation;
+    public ExtendedInformation getExtendedInformation(){
+        return extendedInformation;
+    }
+
+    public void setExtendedInformation(ExtendedInformation value) {
+        extendedInformation = value;
+    }
     
     public String getUri() throws Exception {
         return "api/Payments/Credit";

--- a/src/main/java/SecureNetRestApiSDK/Api/Requests/UpdateVariablePaymentPlanRequest.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Requests/UpdateVariablePaymentPlanRequest.java
@@ -3,6 +3,7 @@
 //
 
 package SecureNetRestApiSDK.Api.Requests;
+import SecureNetRestApiSDK.Api.Models.VariablePaymentPlan;
 
 import SNET.Core.HttpMethodEnum;
 
@@ -26,17 +27,17 @@ public class UpdateVariablePaymentPlanRequest  extends SecureNetRequest
         planId = value;
     }
 
-    private Object plan = new Object();
-    public Object getPlan() {
+    private VariablePaymentPlan plan = new VariablePaymentPlan();
+    public VariablePaymentPlan getPlan() {
         return plan;
     }
 
-    public void setPlan(Object value) {
+    public void setPlan(VariablePaymentPlan value) {
         plan = value;
     }
 
     public String getUri() throws Exception {
-        return String.format("api/Customers/%s/PaymentSchedules/variable/%s", getCustomerId(), getPlan().toString());
+        return String.format("api/Customers/%s/PaymentSchedules/variable/%s", getCustomerId(), getPlanId().toString());
     }
 
     public HttpMethodEnum getMethod() throws Exception {

--- a/src/main/java/SecureNetRestApiSDK/Api/Responses/UpdateVariablePaymentPlanResponse.java
+++ b/src/main/java/SecureNetRestApiSDK/Api/Responses/UpdateVariablePaymentPlanResponse.java
@@ -4,10 +4,37 @@
 
 package SecureNetRestApiSDK.Api.Responses;
 
+import SecureNetRestApiSDK.Api.Models.StoredVariablePaymentPlan;
 import SecureNetRestApiSDK.Api.Responses.SecureNetResponse;
 
 public class UpdateVariablePaymentPlanResponse  extends SecureNetResponse 
 {
+    private Object storedInstallmentPaymentPlan = new Object();
+    public Object getStoredInstallmentPaymentPlan() {
+        return storedInstallmentPaymentPlan;
+    }
+
+    public void setStoredInstallmentPaymentPlan(Object value) {
+        storedInstallmentPaymentPlan = value;
+    }
+
+    private Object storedRecurringPaymentPlan;
+    public Object getStoredRecurringPaymentPlan() {
+        return storedRecurringPaymentPlan;
+    }
+
+    public void setStoredRecurringPaymentPlan(Object value) {
+        storedRecurringPaymentPlan = value;
+    }
+
+    private StoredVariablePaymentPlan storedVariablePaymentPlan = new StoredVariablePaymentPlan();
+    public StoredVariablePaymentPlan getStoredVariablePaymentPlan() {
+        return storedVariablePaymentPlan;
+    }
+
+    public void setStoredVariablePaymentPlan(StoredVariablePaymentPlan value) {
+        storedVariablePaymentPlan = value;
+    }
 }
 
 

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -9,3 +9,4 @@ versionId=1.2
 publicKey=2c28646f-abc4-48f9-af60-6060e5f533d8
 origin=testing.com
 isSoftDescriptorEnabled=true
+isDynamicMCCEnabled=true

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -8,3 +8,4 @@ developerId=12345678
 versionId=1.2
 publicKey=2c28646f-abc4-48f9-af60-6060e5f533d8
 origin=testing.com
+isSoftDescriptorEnabled=true

--- a/src/test/java/test/HelperTest.java
+++ b/src/test/java/test/HelperTest.java
@@ -1,0 +1,34 @@
+package test;
+
+import org.junit.Before;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class HelperTest {
+    private Boolean _isSoftDescriptorEnabled ;
+    private final String SoftDescriptorValue = "Valid Soft Descriptor";
+    private Properties config ;
+    private String _requestSoftDescriptor;
+    private String _responseSoftDescriptor;
+
+    public HelperTest() throws IOException {
+        InputStream stream  = this.getClass().getResourceAsStream("/config.properties");
+        config = new Properties();
+        config.load(stream);
+        _isSoftDescriptorEnabled = Boolean.parseBoolean(config.getProperty("isSoftDescriptorEnabled"));
+        _requestSoftDescriptor = _isSoftDescriptorEnabled ? SoftDescriptorValue : null;
+        _responseSoftDescriptor = _isSoftDescriptorEnabled ? SoftDescriptorValue : "";
+    }
+
+    public String getRequestSoftDescriptor()
+    {
+        return _requestSoftDescriptor;
+    }
+
+    public String getResponseSoftDescriptor()
+    {
+        return _responseSoftDescriptor;
+    }
+}

--- a/src/test/java/test/HelperTest.java
+++ b/src/test/java/test/HelperTest.java
@@ -8,10 +8,14 @@ import java.util.Properties;
 
 public class HelperTest {
     private Boolean _isSoftDescriptorEnabled ;
+    private Boolean _isDynamicMCCEnabled ;
     private String SoftDescriptorValue = "Valid Soft Descriptor";
+    private String DynamicMCCValue = "2047";
     private Properties config ;
     private String _requestSoftDescriptor;
     private String _responseSoftDescriptor;
+    private String _requestDynamicMCC;
+    private String _responseDynamicMCC;
 
     public HelperTest() throws IOException {
         InputStream stream  = this.getClass().getResourceAsStream("/config.properties");
@@ -20,6 +24,9 @@ public class HelperTest {
         _isSoftDescriptorEnabled = Boolean.parseBoolean(config.getProperty("isSoftDescriptorEnabled"));
         _requestSoftDescriptor = _isSoftDescriptorEnabled ? SoftDescriptorValue : null;
         _responseSoftDescriptor = _isSoftDescriptorEnabled ? SoftDescriptorValue : "";
+        _isDynamicMCCEnabled = Boolean.parseBoolean(config.getProperty("isDynamicMCCEnabled"));
+        _requestDynamicMCC = _isDynamicMCCEnabled ? DynamicMCCValue : null;
+        _responseDynamicMCC = _isDynamicMCCEnabled ? DynamicMCCValue : "";
     }
 
     public String getRequestSoftDescriptor()
@@ -30,5 +37,15 @@ public class HelperTest {
     public String getResponseSoftDescriptor()
     {
         return _responseSoftDescriptor;
+    }
+
+    public String getRequestDynamicMCC()
+    {
+        return _requestDynamicMCC;
+    }
+
+    public String getResponseDynamicMCC()
+    {
+        return _responseDynamicMCC;
     }
 }

--- a/src/test/java/test/HelperTest.java
+++ b/src/test/java/test/HelperTest.java
@@ -8,7 +8,7 @@ import java.util.Properties;
 
 public class HelperTest {
     private Boolean _isSoftDescriptorEnabled ;
-    private final String SoftDescriptorValue = "Valid Soft Descriptor";
+    private String SoftDescriptorValue = "Valid Soft Descriptor";
     private Properties config ;
     private String _requestSoftDescriptor;
     private String _responseSoftDescriptor;

--- a/src/test/java/test/controllers/CustomersControllerTest.java
+++ b/src/test/java/test/controllers/CustomersControllerTest.java
@@ -718,7 +718,7 @@ public class CustomersControllerTest {
 		card.setAddress(getAddress());
 		card.setCvv("123");
 		card.setExpirationDate("07/2018");
-		card.setNumber("5555111111111111");
+		card.setNumber("4111111111111111");
 		return card;
 	}
 	

--- a/src/test/java/test/controllers/CustomersControllerTest.java
+++ b/src/test/java/test/controllers/CustomersControllerTest.java
@@ -448,6 +448,7 @@ public class CustomersControllerTest {
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		Assert.assertEquals(response.getStoredRecurringPaymentPlan().getSoftDescriptor(), helper.getResponseSoftDescriptor());
+		Assert.assertEquals(response.getStoredRecurringPaymentPlan().getDynamicMCC(), helper.getResponseDynamicMCC());
 
 		return response.getPlanId();
 	}
@@ -467,6 +468,7 @@ public class CustomersControllerTest {
         plan.setNotes("This is a recurring plan");
         plan.setActive(true);
 		plan.setSoftDescriptor(helper.getRequestSoftDescriptor());
+		plan.setDynamicMCC(helper.getRequestDynamicMCC());
 		return plan;
 	}
 
@@ -494,6 +496,7 @@ public class CustomersControllerTest {
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		Assert.assertEquals(response.getStoredRecurringPaymentPlan().getSoftDescriptor(), helper.getResponseSoftDescriptor());
+		Assert.assertEquals(response.getStoredRecurringPaymentPlan().getDynamicMCC(), helper.getResponseDynamicMCC());
 	}
 
 	// Delete the Customer
@@ -520,6 +523,7 @@ public class CustomersControllerTest {
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		Assert.assertEquals(response.getStoredInstallmentPaymentPlan().getSoftDescriptor(), helper.getResponseSoftDescriptor());
+		Assert.assertEquals(response.getStoredInstallmentPaymentPlan().getDynamicMCC(), helper.getResponseDynamicMCC());
 
 		return response.getPlanId();
 	}
@@ -539,6 +543,7 @@ public class CustomersControllerTest {
         plan.setActive(true);
         plan.setPrimaryPaymentMethodId(paymentMethodId);
 		plan.setSoftDescriptor(helper.getRequestSoftDescriptor());
+		plan.setDynamicMCC(helper.getRequestDynamicMCC());
 		return plan;
 	}
 
@@ -555,6 +560,7 @@ public class CustomersControllerTest {
 		plan.setPrimaryPaymentMethodId(paymentMethodId);
 		plan.setNotes("This is a variable plan");
 		plan.setSoftDescriptor(helper.getRequestSoftDescriptor());
+		plan.setDynamicMCC(helper.getRequestDynamicMCC());
 		plan.setScheduledPayments(getSchedule());
 		return plan;
 	}
@@ -580,6 +586,7 @@ public class CustomersControllerTest {
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		Assert.assertEquals(response.getStoredInstallmentPaymentPlan().getSoftDescriptor(), helper.getResponseSoftDescriptor());
+		Assert.assertEquals(response.getStoredInstallmentPaymentPlan().getDynamicMCC(), helper.getResponseDynamicMCC());
 	}
 
 	/**
@@ -605,6 +612,7 @@ public class CustomersControllerTest {
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		Assert.assertEquals(response.getStoredVariablePaymentPlan().getSoftDescriptor(), helper.getResponseSoftDescriptor());
+		Assert.assertEquals(response.getStoredVariablePaymentPlan().getDynamicMCC(), helper.getResponseDynamicMCC());
 
 		return response.getPlanId();
 	}
@@ -631,6 +639,7 @@ public class CustomersControllerTest {
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		Assert.assertEquals(response.getStoredVariablePaymentPlan().getSoftDescriptor(), helper.getResponseSoftDescriptor());
+		Assert.assertEquals(response.getStoredVariablePaymentPlan().getDynamicMCC(), helper.getResponseDynamicMCC());
 	}
 
 	/**

--- a/src/test/java/test/controllers/CustomersControllerTest.java
+++ b/src/test/java/test/controllers/CustomersControllerTest.java
@@ -718,7 +718,7 @@ public class CustomersControllerTest {
 		card.setAddress(getAddress());
 		card.setCvv("123");
 		card.setExpirationDate("07/2018");
-		card.setNumber("4111111111111111");
+		card.setNumber("5555111111111111");
 		return card;
 	}
 	

--- a/src/test/java/test/controllers/CustomersControllerTest.java
+++ b/src/test/java/test/controllers/CustomersControllerTest.java
@@ -4,6 +4,8 @@
 package test.controllers;
 
 import java.io.InputStream;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -23,6 +25,8 @@ import SecureNetRestApiSDK.Api.Models.InstallmentPaymentPlan;
 import SecureNetRestApiSDK.Api.Models.PaymentVaultToken;
 import SecureNetRestApiSDK.Api.Models.RecurringPaymentPlan;
 import SecureNetRestApiSDK.Api.Models.UserDefinedField;
+import SecureNetRestApiSDK.Api.Models.VariablePaymentPlan;
+import SecureNetRestApiSDK.Api.Models.Schedule;
 import SecureNetRestApiSDK.Api.Requests.AddInstallmentPaymentPlanRequest;
 import SecureNetRestApiSDK.Api.Requests.AddPaymentMethodRequest;
 import SecureNetRestApiSDK.Api.Requests.AddRecurringPaymentPlanRequest;
@@ -129,8 +133,8 @@ public class CustomersControllerTest {
 		// Act
 		/* [UNSUPPORTED] 'var' as type is unsupported "var" */
 		VaultCustomerAndPaymentMethodResponse response = (VaultCustomerAndPaymentMethodResponse) controller.processRequest(apiContext, request,VaultCustomerAndPaymentMethodResponse.class);
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		// Assert
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 	}
 
 	/**
@@ -151,8 +155,8 @@ public class CustomersControllerTest {
 		// Act
 		/* [UNSUPPORTED] 'var' as type is unsupported "var" */
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
-		Assert.assertTrue(response.toResponseString(),response.getSuccess());
 		// Assert
+		Assert.assertTrue(response.toResponseString(),response.getSuccess());
 	}
 
 	/**
@@ -176,8 +180,8 @@ public class CustomersControllerTest {
 		recurringBillingRetrievePaymentPlanRequestReturnsSuccessfully(
 				customerId, planId);
 		// Update the Installment Plan
-		/*recurringBillingUpdateInstallmentPlanRequestReturnsSuccessfully(
-				customerId, planId);*/
+		recurringBillingUpdateInstallmentPlanrequestReturnsSuccessfully(
+				customerId, planId);
 		// Delete the Payment Account
 		/*secureNetVaultDeletePaymentAccountRequestReturnsSuccessfully(
 				customerId, paymentMethodId);*/
@@ -205,6 +209,34 @@ public class CustomersControllerTest {
 				customerId, planId);
 		// Update the Recurring Payment Plan
 		recurringBillingUpdateRecurringPaymentPlanRequestReturnsSuccessfully(
+				customerId, planId);
+		// Delete the Payment Account
+		/*secureNetVaultDeletePaymentAccountRequestReturnsSuccessfully(
+				customerId, paymentMethodId);*/
+	}
+
+	/**
+	 * Unit Tests for Creating a Payment Account, Creating a Variable Payment
+	 * Plan, Updating the Variable Payment Plan, Retrieving the Variable
+	 * Payment Plan, and deleting the Variable Payment Plan requests. Tests
+	 * combined in one method to pass the required payment method identifier,
+	 * the plan identifier and to guaranteee the order of operation.
+	 */
+	@Test
+	public void recurringBillingCreateRetrieveUpdateAndDeleteVariablePaymentPlanRequestsReturnsSuccessfully()
+			throws Exception {
+		// Create the Customer
+		String customerId = secureNetVaultCreateCustomerRequestReturnsSuccessfully();
+		// Create the Payment Account
+		String paymentMethodId = secureNetVaultCreatePaymentAccountRequestReturnsSuccessfully(customerId);
+		// Create the Variable Payment Plan
+		String planId = recurringBillingCreateVariablePaymentPlanRequestReturnsSuccessfully(
+				customerId, paymentMethodId);
+		// Retrieve the Variable Payment Plan
+		recurringBillingRetrievePaymentPlanRequestReturnsSuccessfully(
+				customerId, planId);
+		// Update the Variable Payment Plan
+		recurringBillingUpdateVariablePaymentPlanRequestReturnsSuccessfully(
 				customerId, planId);
 		// Delete the Payment Account
 		/*secureNetVaultDeletePaymentAccountRequestReturnsSuccessfully(
@@ -383,8 +415,8 @@ public class CustomersControllerTest {
 		// Act
 		/* [UNSUPPORTED] 'var' as type is unsupported "var" */
 		RemovePaymentMethodResponse response = (RemovePaymentMethodResponse) controller.processRequest(apiContext, request,RemovePaymentMethodResponse.class);
-		Assert.assertTrue(response.toResponseString(),response.getSuccess());
 		// Assert
+		Assert.assertTrue(response.toResponseString(),response.getSuccess());
 	}
 
 	// Delete the Customer
@@ -409,8 +441,10 @@ public class CustomersControllerTest {
 		AddRecurringPaymentPlanResponse response = (AddRecurringPaymentPlanResponse) controller
 				.processRequest(apiContext, request,
 						AddRecurringPaymentPlanResponse.class);
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		// Assert
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+		Assert.assertEquals(response.getStoredRecurringPaymentPlan().getSoftDescriptor(), request.getPlan().getSoftDescriptor());
+
 		return response.getPlanId();
 	}
 
@@ -428,6 +462,7 @@ public class CustomersControllerTest {
         plan.setPrimaryPaymentMethodId(paymentMethodId);
         plan.setNotes("This is a recurring plan");
         plan.setActive(true);
+		plan.setSoftDescriptor("Rec Plan SoftDesc");
 		return plan;
 	}
 
@@ -452,8 +487,9 @@ public class CustomersControllerTest {
 		// Act
 		/* [UNSUPPORTED] 'var' as type is unsupported "var" */
 		UpdateRecurringPaymentPlanResponse response = (UpdateRecurringPaymentPlanResponse) controller.processRequest(apiContext, request,UpdateRecurringPaymentPlanResponse.class);
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		// Assert
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+		Assert.assertEquals(response.getStoredRecurringPaymentPlan().getSoftDescriptor(), request.getPlan().getSoftDescriptor());
 	}
 
 	// Delete the Customer
@@ -478,6 +514,9 @@ public class CustomersControllerTest {
 				.processRequest(apiContext, request,
 						AddInstallmentPaymentPlanResponse.class);
 		// Assert
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+		Assert.assertEquals(response.getStoredInstallmentPaymentPlan().getSoftDescriptor(), request.getPlan().getSoftDescriptor());
+
 		return response.getPlanId();
 	}
 
@@ -495,6 +534,24 @@ public class CustomersControllerTest {
         plan.setNotes("This is a installment plan");
         plan.setActive(true);
         plan.setPrimaryPaymentMethodId(paymentMethodId);
+		plan.setSoftDescriptor("Inst Plan SoftDesc");
+		return plan;
+	}
+
+	private VariablePaymentPlan getVariablePaymentPlan(String paymentMethodId) {
+		VariablePaymentPlan plan = new VariablePaymentPlan();
+		SimpleDateFormat format = new SimpleDateFormat("MM/dd/yyyy");
+		try {
+			plan.setPlanStartDate(format.parse("07/02/2017"));
+			plan.setPlanEndDate(format.parse("08/05/2018"));
+		} catch (ParseException e) {
+			e.printStackTrace();
+		}
+		plan.setMaxRetries(4);
+		plan.setPrimaryPaymentMethodId(paymentMethodId);
+		plan.setNotes("This is a variable plan");
+		plan.setSoftDescriptor("Var Plan SoftDesc");
+		plan.setScheduledPayments(getSchedule());
 		return plan;
 	}
 
@@ -516,8 +573,9 @@ public class CustomersControllerTest {
 		// Act
 		/* [UNSUPPORTED] 'var' as type is unsupported "var" */
 		UpdateInstallmentPaymentPlanResponse response = (UpdateInstallmentPaymentPlanResponse) controller.processRequest(apiContext, request,UpdateInstallmentPaymentPlanResponse.class);
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		// Assert
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+		Assert.assertEquals(response.getStoredInstallmentPaymentPlan().getSoftDescriptor(), request.getPlan().getSoftDescriptor());
 	}
 
 	/**
@@ -532,6 +590,7 @@ public class CustomersControllerTest {
 		AddVariablePaymentPlanRequest request = new AddVariablePaymentPlanRequest();
 		request.setCustomerId(customerId);
 		request.setDeveloperApplication(getDeveloperApplication());
+		request.setPlan(getVariablePaymentPlan(paymentMethodId));
 		APIContext apiContext = new APIContext();
 		CustomersController controller = new CustomersController();
 		// Act
@@ -540,6 +599,9 @@ public class CustomersControllerTest {
 				.processRequest(apiContext, request,
 						AddVariablePaymentPlanResponse.class);
 		// Assert
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+		Assert.assertEquals(response.getStoredVariablePaymentPlan().getSoftDescriptor(), request.getPlan().getSoftDescriptor());
+
 		return response.getPlanId();
 	}
 
@@ -556,13 +618,15 @@ public class CustomersControllerTest {
 		request.setCustomerId(customerId);
 		request.setPlanId(planId);
 		request.setDeveloperApplication(getDeveloperApplication());
+		request.setPlan(getVariablePaymentPlan("1"));
 		APIContext apiContext = new APIContext();
 		CustomersController controller = new CustomersController();
 		// Act
 		/* [UNSUPPORTED] 'var' as type is unsupported "var" */
 		UpdateVariablePaymentPlanResponse response = (UpdateVariablePaymentPlanResponse) controller.processRequest(apiContext, request,UpdateVariablePaymentPlanResponse.class);
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		// Assert
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+		Assert.assertEquals(response.getStoredVariablePaymentPlan().getSoftDescriptor(), request.getPlan().getSoftDescriptor());
 	}
 
 	/**
@@ -664,6 +728,22 @@ public class CustomersControllerTest {
 		paymentVaultToken.setPaymentMethodId(paymentMethodId);
 		paymentVaultToken.setPaymentType("CREDIT_CARD");
 		return paymentVaultToken;
+	}
+
+	private List<Schedule> getSchedule() {
+		SimpleDateFormat format = new SimpleDateFormat("MM/dd/yyyy");
+		List<Schedule> list = new ArrayList<Schedule>();
+		Schedule schedule = new Schedule();
+		schedule.setInstallmentDate("08/05/2017");
+		schedule.setAmount(4);
+		try {
+			schedule.setPaymentdate(format.parse("08/06/2017"));
+		} catch (ParseException e) {
+			e.printStackTrace();
+		}
+		schedule.setScheduleId(1093920);
+		list.add(schedule);
+		return list;
 	}
 
 }

--- a/src/test/java/test/controllers/CustomersControllerTest.java
+++ b/src/test/java/test/controllers/CustomersControllerTest.java
@@ -3,6 +3,7 @@
 
 package test.controllers;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -59,16 +60,19 @@ import SecureNetRestApiSDK.Api.Responses.UpdatePaymentMethodResponse;
 import SecureNetRestApiSDK.Api.Responses.UpdateRecurringPaymentPlanResponse;
 import SecureNetRestApiSDK.Api.Responses.UpdateVariablePaymentPlanResponse;
 import SecureNetRestApiSDK.Api.Responses.VaultCustomerAndPaymentMethodResponse;
+import test.HelperTest;
 
 public class CustomersControllerTest {
 	
 	Properties config ;
+	HelperTest helper;
 	
 	@Before
 	public void before() throws Exception{
 		InputStream stream  = this.getClass().getResourceAsStream("/config.properties");
 		config = new Properties();
 		config.load(stream);
+		helper = new HelperTest();
 	}
 	
 	
@@ -443,7 +447,7 @@ public class CustomersControllerTest {
 						AddRecurringPaymentPlanResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
-		Assert.assertEquals(response.getStoredRecurringPaymentPlan().getSoftDescriptor(), request.getPlan().getSoftDescriptor());
+		Assert.assertEquals(response.getStoredRecurringPaymentPlan().getSoftDescriptor(), helper.getResponseSoftDescriptor());
 
 		return response.getPlanId();
 	}
@@ -462,7 +466,7 @@ public class CustomersControllerTest {
         plan.setPrimaryPaymentMethodId(paymentMethodId);
         plan.setNotes("This is a recurring plan");
         plan.setActive(true);
-		plan.setSoftDescriptor("Rec Plan SoftDesc");
+		plan.setSoftDescriptor(helper.getRequestSoftDescriptor());
 		return plan;
 	}
 
@@ -489,7 +493,7 @@ public class CustomersControllerTest {
 		UpdateRecurringPaymentPlanResponse response = (UpdateRecurringPaymentPlanResponse) controller.processRequest(apiContext, request,UpdateRecurringPaymentPlanResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
-		Assert.assertEquals(response.getStoredRecurringPaymentPlan().getSoftDescriptor(), request.getPlan().getSoftDescriptor());
+		Assert.assertEquals(response.getStoredRecurringPaymentPlan().getSoftDescriptor(), helper.getResponseSoftDescriptor());
 	}
 
 	// Delete the Customer
@@ -515,7 +519,7 @@ public class CustomersControllerTest {
 						AddInstallmentPaymentPlanResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
-		Assert.assertEquals(response.getStoredInstallmentPaymentPlan().getSoftDescriptor(), request.getPlan().getSoftDescriptor());
+		Assert.assertEquals(response.getStoredInstallmentPaymentPlan().getSoftDescriptor(), helper.getResponseSoftDescriptor());
 
 		return response.getPlanId();
 	}
@@ -534,7 +538,7 @@ public class CustomersControllerTest {
         plan.setNotes("This is a installment plan");
         plan.setActive(true);
         plan.setPrimaryPaymentMethodId(paymentMethodId);
-		plan.setSoftDescriptor("Inst Plan SoftDesc");
+		plan.setSoftDescriptor(helper.getRequestSoftDescriptor());
 		return plan;
 	}
 
@@ -550,7 +554,7 @@ public class CustomersControllerTest {
 		plan.setMaxRetries(4);
 		plan.setPrimaryPaymentMethodId(paymentMethodId);
 		plan.setNotes("This is a variable plan");
-		plan.setSoftDescriptor("Var Plan SoftDesc");
+		plan.setSoftDescriptor(helper.getRequestSoftDescriptor());
 		plan.setScheduledPayments(getSchedule());
 		return plan;
 	}
@@ -575,7 +579,7 @@ public class CustomersControllerTest {
 		UpdateInstallmentPaymentPlanResponse response = (UpdateInstallmentPaymentPlanResponse) controller.processRequest(apiContext, request,UpdateInstallmentPaymentPlanResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
-		Assert.assertEquals(response.getStoredInstallmentPaymentPlan().getSoftDescriptor(), request.getPlan().getSoftDescriptor());
+		Assert.assertEquals(response.getStoredInstallmentPaymentPlan().getSoftDescriptor(), helper.getResponseSoftDescriptor());
 	}
 
 	/**
@@ -600,7 +604,7 @@ public class CustomersControllerTest {
 						AddVariablePaymentPlanResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
-		Assert.assertEquals(response.getStoredVariablePaymentPlan().getSoftDescriptor(), request.getPlan().getSoftDescriptor());
+		Assert.assertEquals(response.getStoredVariablePaymentPlan().getSoftDescriptor(), helper.getResponseSoftDescriptor());
 
 		return response.getPlanId();
 	}
@@ -626,7 +630,7 @@ public class CustomersControllerTest {
 		UpdateVariablePaymentPlanResponse response = (UpdateVariablePaymentPlanResponse) controller.processRequest(apiContext, request,UpdateVariablePaymentPlanResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
-		Assert.assertEquals(response.getStoredVariablePaymentPlan().getSoftDescriptor(), request.getPlan().getSoftDescriptor());
+		Assert.assertEquals(response.getStoredVariablePaymentPlan().getSoftDescriptor(), helper.getResponseSoftDescriptor());
 	}
 
 	/**

--- a/src/test/java/test/controllers/PaymentsControllerTest.java
+++ b/src/test/java/test/controllers/PaymentsControllerTest.java
@@ -3,6 +3,7 @@
 
 package test.controllers;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
@@ -30,16 +31,19 @@ import SecureNetRestApiSDK.Api.Responses.CreditResponse;
 import SecureNetRestApiSDK.Api.Responses.PriorAuthCaptureResponse;
 import SecureNetRestApiSDK.Api.Responses.RefundResponse;
 import SecureNetRestApiSDK.Api.Responses.VoidResponse;
+import test.HelperTest;
 
 public class PaymentsControllerTest {
 	
 	Properties config ;
+	HelperTest helper;
 	
 	@Before
 	public void before() throws Exception{
 		InputStream stream  = this.getClass().getResourceAsStream("/config.properties");
 		config = new Properties();
 		config.load(stream);
+		helper = new HelperTest();
 	}
 	/**
 	 * Unit Tests for an AuthorizationOnly request and a subsequent
@@ -84,7 +88,7 @@ public class PaymentsControllerTest {
 		AuthorizeResponse response = (AuthorizeResponse) controller.processRequest(apiContext, request,AuthorizeResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
-		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
 
 		return response.getTransaction().getTransactionId();
 	}
@@ -111,7 +115,7 @@ public class PaymentsControllerTest {
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
-		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
 	}
 
 	/**
@@ -156,7 +160,7 @@ public class PaymentsControllerTest {
 		AuthorizeResponse response = (AuthorizeResponse) controller.processRequest(apiContext, request,AuthorizeResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
-		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
 
 		return response.getTransaction().getTransactionId();
 	}
@@ -183,7 +187,7 @@ public class PaymentsControllerTest {
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
-		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
 	}
 
 	/**
@@ -229,7 +233,7 @@ public class PaymentsControllerTest {
 		AuthorizeResponse response = (AuthorizeResponse) controller.processRequest(apiContext, request,AuthorizeResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
-		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
 
 		return response.getTransaction().getTransactionId();
 	}
@@ -259,7 +263,7 @@ public class PaymentsControllerTest {
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
-		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
 	}
 
 	/**
@@ -284,7 +288,7 @@ public class PaymentsControllerTest {
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
-		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
 	}
 
 	/**
@@ -308,7 +312,7 @@ public class PaymentsControllerTest {
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
-		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
 	}
 
 	/**
@@ -364,7 +368,7 @@ public class PaymentsControllerTest {
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
-		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
 	}
 
 	/**
@@ -436,7 +440,7 @@ public class PaymentsControllerTest {
 		CreditResponse  response = (CreditResponse) controller.processRequest(apiContext, request,CreditResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
-		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
 	}
 
 	/**
@@ -477,7 +481,7 @@ public class PaymentsControllerTest {
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
-		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
 
 		return response.getTransaction().getTransactionId();
 	}
@@ -520,7 +524,7 @@ public class PaymentsControllerTest {
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
-		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
 
 		return response.getTransaction().getTransactionId();
 	}
@@ -563,7 +567,7 @@ public class PaymentsControllerTest {
 
 	private ExtendedInformation getExtendedInformation() {
 		ExtendedInformation extendedInfo = new ExtendedInformation();
-		extendedInfo.setSoftDescriptor("Soft Descriptor");
+		extendedInfo.setSoftDescriptor(helper.getRequestSoftDescriptor());
 		return extendedInfo;
 	}
 }

--- a/src/test/java/test/controllers/PaymentsControllerTest.java
+++ b/src/test/java/test/controllers/PaymentsControllerTest.java
@@ -49,6 +49,7 @@ public class PaymentsControllerTest {
 	@Test
 	public void creditCardPresentAuthorizationOnlyAndPriorAuthCaptureRequestsReturnsSuccessfully()
 			throws Exception {
+		// Arrange
 		int transactionId = creditCardPresentAuthorizationOnlyRequestReturnsSuccessfully();
 		PriorAuthCaptureRequest request = new PriorAuthCaptureRequest();
 		request.setAmount(20d);
@@ -56,7 +57,9 @@ public class PaymentsControllerTest {
 		request.setDeveloperApplication(getDeveloperApplication());
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
+		// Act
 		PriorAuthCaptureResponse response = (PriorAuthCaptureResponse) controller.processRequest(apiContext, request, PriorAuthCaptureResponse.class);
+		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 	}
 
@@ -74,12 +77,15 @@ public class PaymentsControllerTest {
 		request.setAddToVault(true);
 		request.setAmount(20d);
 		request.setDeveloperApplication(getDeveloperApplication());
+		request.setExtendedInformation(getExtendedInformation());
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
 		// Act
 		AuthorizeResponse response = (AuthorizeResponse) controller.processRequest(apiContext, request,AuthorizeResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
+
 		return response.getTransaction().getTransactionId();
 	}
 
@@ -98,14 +104,14 @@ public class PaymentsControllerTest {
 		request.setAmount(20d);
 		request.setCard(getCard());
 		request.setDeveloperApplication(getDeveloperApplication());
+		request.setExtendedInformation(getExtendedInformation());
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
 		// Act
-		 
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		// Assert
-
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
 	}
 
 	/**
@@ -125,8 +131,8 @@ public class PaymentsControllerTest {
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
 		// Act
-
 		PriorAuthCaptureResponse response = (PriorAuthCaptureResponse) controller.processRequest(apiContext, request,PriorAuthCaptureResponse.class);
+		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 	}
 
@@ -143,13 +149,15 @@ public class PaymentsControllerTest {
 		request.setCard(getCard());
 		request.setAmount(20d);
 		request.setDeveloperApplication(getDeveloperApplication());
+		request.setExtendedInformation(getExtendedInformation());
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
 		// Act
-		 
 		AuthorizeResponse response = (AuthorizeResponse) controller.processRequest(apiContext, request,AuthorizeResponse.class);
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		// Assert
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
+
 		return response.getTransaction().getTransactionId();
 	}
 
@@ -168,14 +176,14 @@ public class PaymentsControllerTest {
 		request.setCard(getCard());
 		request.setDeveloperApplication(getDeveloperApplication());
 		request.setAmount(20d);
+		request.setExtendedInformation(getExtendedInformation());
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
 		// Act
-		 
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		// Assert
-
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
 	}
 
 	/**
@@ -186,6 +194,7 @@ public class PaymentsControllerTest {
 	@Test
 	public void creditCardNotPresentAuthorizationOnlyAndPriorAuthCaptureRequestsReturnsSuccessfully()
 			throws Exception {
+		// Arrange
 		int transactionId = creditCardNotPresentAuthorizationOnlyRequestReturnsSuccessfully();
 		PriorAuthCaptureRequest request = new PriorAuthCaptureRequest();
 		request.setAmount(10d);
@@ -194,8 +203,8 @@ public class PaymentsControllerTest {
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
 		// Act
-		 
 		PriorAuthCaptureResponse response = (PriorAuthCaptureResponse) controller.processRequest(apiContext, request,PriorAuthCaptureResponse.class);
+		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 	}
 
@@ -213,13 +222,15 @@ public class PaymentsControllerTest {
 		request.setCard(getCard());
 		request.setAddToVault(true);
 		request.setAmount(20d);
+		request.setExtendedInformation(getExtendedInformation());
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
 		// Act
-		 
 		AuthorizeResponse response = (AuthorizeResponse) controller.processRequest(apiContext, request,AuthorizeResponse.class);
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
+
 		return response.getTransaction().getTransactionId();
 	}
 
@@ -239,17 +250,16 @@ public class PaymentsControllerTest {
 		request.setAddToVault(true);
 		request.setAmount(100d);
 		request.setDeveloperApplication(getDeveloperApplication());
-		ExtendedInformation extendedInfo = new ExtendedInformation();
+		ExtendedInformation extendedInfo = getExtendedInformation();
 		extendedInfo.setTypeOfGoods("PHYSICAL");
 		request.setExtendedInformation(extendedInfo);
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
 		// Act
-		 
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		// Assert
-
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
 	}
 
 	/**
@@ -265,17 +275,16 @@ public class PaymentsControllerTest {
 		request.setCard(getCard());
 		request.setAmount(80d);
 		request.setDeveloperApplication(getDeveloperApplication());
-		ExtendedInformation extendedInfo = new ExtendedInformation();
+		ExtendedInformation extendedInfo = getExtendedInformation();
 		extendedInfo.setTypeOfGoods("PHYSICAL");
 		request.setExtendedInformation(extendedInfo);
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
 		// Act
-		 
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		// Assert
-
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
 	}
 
 	/**
@@ -290,17 +299,16 @@ public class PaymentsControllerTest {
 		request.setCard(getCard());
 		request.setAmount(80d);
 		request.setDeveloperApplication(getDeveloperApplication());
-		ExtendedInformation extendedInfo = new ExtendedInformation();
+		ExtendedInformation extendedInfo = getExtendedInformation();
 		extendedInfo.setTypeOfGoods("PHYSICAL");
 		request.setExtendedInformation(extendedInfo);
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
 		// Act
-		 
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		// Assert
-
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
 	}
 
 	/**
@@ -318,11 +326,9 @@ public class PaymentsControllerTest {
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
 		// Act
-		 
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		// Assert
-
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 	}
 
 	/**
@@ -356,9 +362,9 @@ public class PaymentsControllerTest {
 		PaymentsController controller = new PaymentsController();
 		// Act
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		// Assert
-
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
 	}
 
 	/**
@@ -381,11 +387,9 @@ public class PaymentsControllerTest {
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
 		// Act
-		 
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		// Assert
-
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 	}
 
 	/**
@@ -408,11 +412,9 @@ public class PaymentsControllerTest {
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
 		// Act
-		 
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		// Assert
-
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 	}
 
 	/**
@@ -427,14 +429,14 @@ public class PaymentsControllerTest {
 		request.setCard(getCard());
 		request.setAmount(1.05d);
 		request.setDeveloperApplication(getDeveloperApplication());
+		request.setExtendedInformation(getExtendedInformation());
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
 		// Act
-		 
 		CreditResponse  response = (CreditResponse) controller.processRequest(apiContext, request,CreditResponse.class);
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		// Assert
-
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
 	}
 
 	/**
@@ -452,8 +454,8 @@ public class PaymentsControllerTest {
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
 		// Act
-		 
 		RefundResponse response = (RefundResponse) controller.processRequest(apiContext, request,RefundResponse.class);
+		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 	}
 
@@ -468,13 +470,14 @@ public class PaymentsControllerTest {
 		request.setCard(getCard());
 		request.setAmount(10d);
 		request.setDeveloperApplication(getDeveloperApplication());
+		request.setExtendedInformation(getExtendedInformation());
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
 		// Act
-		 
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		// Assert
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
 
 		return response.getTransaction().getTransactionId();
 	}
@@ -494,8 +497,8 @@ public class PaymentsControllerTest {
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
 		// Act
-		 
 		VoidResponse response = (VoidResponse) controller.processRequest(apiContext, request,VoidResponse.class);
+		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 	}
 
@@ -510,13 +513,14 @@ public class PaymentsControllerTest {
 		request.setCard(getCard());
 		request.setAmount(10d);
 		request.setDeveloperApplication(getDeveloperApplication());
+		request.setExtendedInformation(getExtendedInformation());
 		APIContext apiContext = new APIContext();
 		PaymentsController controller = new PaymentsController();
 		// Act
-		 
 		ChargeResponse response = (ChargeResponse) controller.processRequest(apiContext, request,ChargeResponse.class);
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		// Assert
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), request.getExtendedInformation().getSoftDescriptor());
 
 		return response.getTransaction().getTransactionId();
 	}
@@ -555,5 +559,11 @@ public class PaymentsControllerTest {
 		check.setRoutingNumber("222371863");
 		check.setAccountNumber("123456");
 		return check;
+	}
+
+	private ExtendedInformation getExtendedInformation() {
+		ExtendedInformation extendedInfo = new ExtendedInformation();
+		extendedInfo.setSoftDescriptor("Soft Descriptor");
+		return extendedInfo;
 	}
 }

--- a/src/test/java/test/controllers/PaymentsControllerTest.java
+++ b/src/test/java/test/controllers/PaymentsControllerTest.java
@@ -87,9 +87,10 @@ public class PaymentsControllerTest {
 		// Act
 		AuthorizeResponse response = (AuthorizeResponse) controller.processRequest(apiContext, request,AuthorizeResponse.class);
 		// Assert
+
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
-
+		Assert.assertEquals(response.getTransaction().getDynamicMCC(), helper.getResponseDynamicMCC());
 		return response.getTransaction().getTransactionId();
 	}
 
@@ -116,6 +117,7 @@ public class PaymentsControllerTest {
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getDynamicMCC(), helper.getResponseDynamicMCC());
 	}
 
 	/**
@@ -161,6 +163,7 @@ public class PaymentsControllerTest {
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getDynamicMCC(), helper.getResponseDynamicMCC());
 
 		return response.getTransaction().getTransactionId();
 	}
@@ -188,6 +191,7 @@ public class PaymentsControllerTest {
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getDynamicMCC(), helper.getResponseDynamicMCC());
 	}
 
 	/**
@@ -234,6 +238,7 @@ public class PaymentsControllerTest {
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getDynamicMCC(), helper.getResponseDynamicMCC());
 
 		return response.getTransaction().getTransactionId();
 	}
@@ -264,6 +269,7 @@ public class PaymentsControllerTest {
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getDynamicMCC(), helper.getResponseDynamicMCC());
 	}
 
 	/**
@@ -289,6 +295,7 @@ public class PaymentsControllerTest {
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getDynamicMCC(), helper.getResponseDynamicMCC());
 	}
 
 	/**
@@ -313,6 +320,7 @@ public class PaymentsControllerTest {
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getDynamicMCC(), helper.getResponseDynamicMCC());
 	}
 
 	/**
@@ -369,6 +377,7 @@ public class PaymentsControllerTest {
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getDynamicMCC(), helper.getResponseDynamicMCC());
 	}
 
 	/**
@@ -441,6 +450,7 @@ public class PaymentsControllerTest {
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getDynamicMCC(), helper.getResponseDynamicMCC());
 	}
 
 	/**
@@ -482,6 +492,7 @@ public class PaymentsControllerTest {
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getDynamicMCC(), helper.getResponseDynamicMCC());
 
 		return response.getTransaction().getTransactionId();
 	}
@@ -525,6 +536,7 @@ public class PaymentsControllerTest {
 		// Assert
 		Assert.assertTrue(response.toResponseString(), response.getSuccess());
 		Assert.assertEquals(response.getTransaction().getSoftDescriptor(), helper.getResponseSoftDescriptor());
+		Assert.assertEquals(response.getTransaction().getDynamicMCC(), helper.getResponseDynamicMCC());
 
 		return response.getTransaction().getTransactionId();
 	}
@@ -568,6 +580,7 @@ public class PaymentsControllerTest {
 	private ExtendedInformation getExtendedInformation() {
 		ExtendedInformation extendedInfo = new ExtendedInformation();
 		extendedInfo.setSoftDescriptor(helper.getRequestSoftDescriptor());
+		extendedInfo.setDynamicMCC(helper.getRequestDynamicMCC());
 		return extendedInfo;
 	}
 }

--- a/src/test/java/test/controllers/PrevaultControllerTest.java
+++ b/src/test/java/test/controllers/PrevaultControllerTest.java
@@ -41,6 +41,7 @@ public class PrevaultControllerTest
     
 	@Test
     public void tokenizationCreateTokenUsingCreditCardRequest() throws Exception {
+		// Arrange
         TokenCardRequest request = new TokenCardRequest();
         request.setDeveloperApplication(getDeveloperApplication());
         request.setCard(getCard());
@@ -48,12 +49,15 @@ public class PrevaultControllerTest
         APIContext apiContext = new APIContext();
         apiContext.setHTTPHeaders(getOrigin());
         PreVaultController controller = new PreVaultController();
+		// Act
         TokenCardResponse response = (TokenCardResponse) controller.processRequest(apiContext,request,TokenCardResponse.class);
+		// Assert
         Assert.assertTrue(response.toResponseString(), response.getSuccess());
     }
 	
 	@Test
     public void tokenizationCreateTokenUsingCheckingInformationRequestReturnsSuccessfully() throws Exception {
+		// Arrange
         TokenCheckRequest request = new TokenCheckRequest();
         request.setCheck(getCheck());
         request.setDeveloperApplication(getDeveloperApplication());
@@ -61,7 +65,9 @@ public class PrevaultControllerTest
         APIContext apiContext = new APIContext();
         apiContext.setHTTPHeaders(getOrigin());
         PreVaultController controller = new PreVaultController();
+		// Act
         TokenCheckResponse response = (TokenCheckResponse) controller.processRequest(apiContext,request,TokenCheckResponse.class);
+		// Assert
         Assert.assertTrue(response.toResponseString(), response.getSuccess());
     }
 	

--- a/src/test/java/test/controllers/PrevaultControllerTest.java
+++ b/src/test/java/test/controllers/PrevaultControllerTest.java
@@ -41,7 +41,7 @@ public class PrevaultControllerTest
     
 	@Test
     public void tokenizationCreateTokenUsingCreditCardRequest() throws Exception {
-		// Arrange
+        // Arrange
         TokenCardRequest request = new TokenCardRequest();
         request.setDeveloperApplication(getDeveloperApplication());
         request.setCard(getCard());
@@ -49,15 +49,15 @@ public class PrevaultControllerTest
         APIContext apiContext = new APIContext();
         apiContext.setHTTPHeaders(getOrigin());
         PreVaultController controller = new PreVaultController();
-		// Act
+        // Act
         TokenCardResponse response = (TokenCardResponse) controller.processRequest(apiContext,request,TokenCardResponse.class);
-		// Assert
+        // Assert
         Assert.assertTrue(response.toResponseString(), response.getSuccess());
     }
 	
 	@Test
     public void tokenizationCreateTokenUsingCheckingInformationRequestReturnsSuccessfully() throws Exception {
-		// Arrange
+        // Arrange
         TokenCheckRequest request = new TokenCheckRequest();
         request.setCheck(getCheck());
         request.setDeveloperApplication(getDeveloperApplication());
@@ -65,9 +65,9 @@ public class PrevaultControllerTest
         APIContext apiContext = new APIContext();
         apiContext.setHTTPHeaders(getOrigin());
         PreVaultController controller = new PreVaultController();
-		// Act
+        // Act
         TokenCheckResponse response = (TokenCheckResponse) controller.processRequest(apiContext,request,TokenCheckResponse.class);
-		// Assert
+        // Assert
         Assert.assertTrue(response.toResponseString(), response.getSuccess());
     }
 	

--- a/src/test/java/test/controllers/TransactionsControllerTest.java
+++ b/src/test/java/test/controllers/TransactionsControllerTest.java
@@ -51,7 +51,7 @@ public class TransactionsControllerTest
         TransactionsController controller = new TransactionsController();
         // Act
         TransactionSearchResponse response = (TransactionSearchResponse) controller.processRequest(apiContext,request,TransactionSearchResponse.class);
-		// Assert
+        // Assert
         Assert.assertTrue(response.toResponseString(), response.getSuccess());
     }
 
@@ -70,7 +70,7 @@ public class TransactionsControllerTest
         // Act
         TransactionRetrieveResponse response = (TransactionRetrieveResponse) controller.processRequest(apiContext,request,TransactionRetrieveResponse.class);
         // Assert
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+        Assert.assertTrue(response.toResponseString(), response.getSuccess());
     }
 
     /**
@@ -88,7 +88,7 @@ public class TransactionsControllerTest
         // Act
         TransactionUpdateResponse response = (TransactionUpdateResponse) controller.processRequest(apiContext,request,TransactionUpdateResponse.class);
         // Assert
-		Assert.assertTrue(response.toResponseString(), response.getSuccess());
+        Assert.assertTrue(response.toResponseString(), response.getSuccess());
     }
     
 	private DeveloperApplication getDeveloperApplication() {

--- a/src/test/java/test/controllers/TransactionsControllerTest.java
+++ b/src/test/java/test/controllers/TransactionsControllerTest.java
@@ -43,7 +43,7 @@ public class TransactionsControllerTest
     */
 	@Test
     public void transactionReportingAndManagementSearchTransactionRequestReturnsSuccessfully() throws Exception {
-        // Arramge
+        // Arrange
         TransactionSearchRequest request = new TransactionSearchRequest();
         request.setDeveloperApplication(getDeveloperApplication());
         request.setTransactionId(createTransaction());
@@ -51,8 +51,8 @@ public class TransactionsControllerTest
         TransactionsController controller = new TransactionsController();
         // Act
         TransactionSearchResponse response = (TransactionSearchResponse) controller.processRequest(apiContext,request,TransactionSearchResponse.class);
+		// Assert
         Assert.assertTrue(response.toResponseString(), response.getSuccess());
-        // Assert
     }
 
     /**
@@ -69,8 +69,8 @@ public class TransactionsControllerTest
         TransactionsController controller = new TransactionsController();
         // Act
         TransactionRetrieveResponse response = (TransactionRetrieveResponse) controller.processRequest(apiContext,request,TransactionRetrieveResponse.class);
-        Assert.assertTrue(response.toResponseString(), response.getSuccess());
         // Assert
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
     }
 
     /**
@@ -87,8 +87,8 @@ public class TransactionsControllerTest
         TransactionsController controller = new TransactionsController();
         // Act
         TransactionUpdateResponse response = (TransactionUpdateResponse) controller.processRequest(apiContext,request,TransactionUpdateResponse.class);
-        Assert.assertTrue(response.toResponseString(), response.getSuccess());
         // Assert
+		Assert.assertTrue(response.toResponseString(), response.getSuccess());
     }
     
 	private DeveloperApplication getDeveloperApplication() {


### PR DESCRIPTION
As a WorldPay Total merchant, I want to supply soft descriptor data through the Java SDK so that I can specify a different descriptor for each authorization.

As a WorldPay Total merchant, I want to supply soft descriptor data with AutoBill requests through the Java SDK so that I can specify the descriptor on cardholder statements for each billing transaction.

Implemented with Enable/Disable SoftDescriptor from config